### PR TITLE
feat: upgrade to typescript v2

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -26,4 +26,4 @@ typescript:
   maxMethodParams: 4
   outputModelSuffix: output
   packageName: HoneyHive
-  templateVersion: v1
+  templateVersion: v2


### PR DESCRIPTION
Upgrades the typescript SDK to our v2 generator which has significant improvements. See : https://www.speakeasyapi.dev/post/introducing-universal-ts

Please note this is a breaking change. Since your SDK is in [direct mode](https://www.speakeasyapi.dev/post/introducing-universal-ts) no PR will be created. The SDK version will be major bumped and code updated in place. Please change the linked config to `mode: pr` if you would like a PR to be opened instead.