### PR TITLE
Fix package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeyhive",
-  "version": "1.0.2-experimental.0",
+  "version": "1.0.2",
   "author": "HoneyHive",
   "main": "./index.js",
   "sideEffects": false,


### PR DESCRIPTION
Some stuff got erroneously added to `package.json` in https://github.com/honeyhiveai/typescript-sdk/pull/46, which broke the import.