### PR TITLE
Add custom span tracer

### DIFF
--- a/src/sdk/tracer.ts
+++ b/src/sdk/tracer.ts
@@ -239,13 +239,11 @@ export class HoneyHiveTracer {
               (res: any) => {
                 setSpanAttributes(span, 'honeyhive_outputs.result', res);
                 span.end();
-                console.log(span);
                 return res;
               },
               (err: any) => {
                 span.recordException(err);
                 span.end();
-                console.log(span);
                 throw err;
               }
             ) as ReturnType<T>;
@@ -253,13 +251,11 @@ export class HoneyHiveTracer {
           } else {
             setSpanAttributes(span, 'honeyhive_outputs.result', result);
             span.end();
-            console.log(span);
             return result;
           }
         } catch (err: unknown) {
           span.recordException(err as Exception);
           span.end();
-          console.log(span);
           throw err;
         }
       };


### PR DESCRIPTION
The complement of this change on the Python SDK: https://github.com/honeyhiveai/python-sdk/pull/95

Can be used like this:
```typescript
import { HoneyHiveTracer } from "honeyhive";

const config = { config_stuff: 42 };
const metadata = { metadata_stuff: 1337 };

const HH_API_KEY = process.env.HH_API_KEY || "";
const HH_API_URL = process.env.HH_API_URL;
const HH_PROJECT = process.env.HH_PROJECT || "";
const HH_PROJECT_ID = process.env.HH_PROJECT_ID || "";

const tracer = await HoneyHiveTracer.init({
  apiKey: HH_API_KEY,
  project: HH_PROJECT,
  sessionName: 'my-session-name',
  source: 'my-source',
  serverUrl: HH_API_URL,
});

const myFunction = tracer.traceFunction(config, metadata)(function (param1: string, param2: number) {
  // Your function logic here
  return `Result with ${param1} and ${param2}`;
});

// Call the traced function
myFunction('test', 42);
```