### PR TITLE
support groundTruth for evaluate harness

### DIFF
--- a/src/sdk/evaluation.ts
+++ b/src/sdk/evaluation.ts
@@ -79,19 +79,28 @@ async function loadDataset(hhai: HoneyHive, config: EvaluationConfig): Promise<a
     return null;
 }
 
-async function getInputs(state: EvaluationState, config: EvaluationConfig, run_id: number): Promise<any> {
+async function getDatapoint(state: EvaluationState, config: EvaluationConfig, run_id: number): Promise<{inputs: any, groundTruth: any} | null> {
     if (state.hh_dataset && state.hh_dataset.datapoints && state.hh_dataset.datapoints.length > 0) {
         try {
             const datapoint_id = state.hh_dataset.datapoints[run_id];
             const datapoint_response = await state.hhai.datapoints.getDatapoint(datapoint_id);
             const datapointList = datapoint_response.datapoint;
-            if (datapointList && datapointList[0])
-                return datapointList[0].inputs;
+            if (datapointList && datapointList[0]) {
+                return {
+                    inputs: datapointList[0].inputs || {},
+                    groundTruth: datapointList[0].groundTruth || {}
+                };
+            }
         } catch (error) {
             console.error(`Error getting datapoint: ${error}`);
         }
-    } else if (config.dataset) {
-        return config.dataset[run_id];
+    } else if (config.dataset && config.dataset[run_id]) {
+        const datapoint = config.dataset[run_id];
+        const result = {
+            inputs: datapoint['inputs'] || {},
+            groundTruth: datapoint['ground_truths'] || {}
+        };
+        return result;
     }
     return null;
 }
@@ -112,7 +121,7 @@ async function initializeTracer(config: EvaluationConfig, inputs: any): Promise<
     }
 }
 
-async function runEvaluation(tracer: HoneyHiveTracer, evalconfig: EvaluationConfig, inputs: any): Promise<Any> {
+async function runEvaluation(tracer: HoneyHiveTracer, evalconfig: EvaluationConfig, inputs: any, ground_truths?: any): Promise<Any> {
     try {
         let output = {};
         let promiseResolve: () => void;
@@ -123,7 +132,7 @@ async function runEvaluation(tracer: HoneyHiveTracer, evalconfig: EvaluationConf
         tracer.trace(() => {
             (async () => {
                 try {
-                    const agentResponse = await evalconfig.evaluationFunction(inputs);
+                    const agentResponse = await evalconfig.evaluationFunction(inputs, ground_truths);
                     output = agentResponse;
                     console.log(agentResponse);
                 } finally {
@@ -142,14 +151,14 @@ async function runEvaluation(tracer: HoneyHiveTracer, evalconfig: EvaluationConf
     }
 }
 
-async function runEvaluators(inputs: any, evaluation_output: any, evaluators?: Function[]): Promise<Dict<Any>> {
+async function runEvaluators(inputs: any, evaluation_output: any, evaluators?: Function[], ground_truths?: any): Promise<Dict<Any>> {
     const metrics: Dict<Any> = {};
     if (evaluators) {
         for (let index = 0; index < evaluators.length; index++) {
             try {
                 const evaluator = evaluators[index];
                 if (evaluator) {
-                    const evaluator_result = await evaluator(inputs, evaluation_output);
+                    const evaluator_result = await evaluator(evaluation_output, inputs, ground_truths);
                     if (evaluator_result && typeof evaluator_result === 'object') {
                         Object.assign(metrics, evaluator_result);
                         continue;
@@ -244,12 +253,11 @@ async function evaluate(
     await setupEvaluation(state, config);
 
     for (let run_id = 0; run_id < runs; run_id++) {
-        console.log(`---------- RUN ${run_id + 1} ----------`)
-        const inputs = await getInputs(state, config, run_id);
-        const tracer = await initializeTracer(config, inputs);
+        const datapoint = await getDatapoint(state, config, run_id);
+        const tracer = await initializeTracer(config, datapoint?.inputs);
 
-        const output = await runEvaluation(tracer, config, inputs);
-        const metrics = await runEvaluators(inputs, output, config.evaluators);
+        const output = await runEvaluation(tracer, config, datapoint?.inputs, datapoint?.groundTruth);
+        const metrics = await runEvaluators(datapoint?.inputs, output, config.evaluators, datapoint?.groundTruth);
 
         await addTraceMetadata(tracer, state, config, output, metrics, run_id);
 

--- a/tests/evaluate.test.ts
+++ b/tests/evaluate.test.ts
@@ -1,27 +1,84 @@
-// tests/evaluate.test.ts
 import { evaluate } from "honeyhive";
 
 const HH_API_KEY = process.env.HH_API_KEY || "";
 const HH_PROJECT_NAME = process.env.HH_PROJECT_NAME || "";
 const SERVER_URL = "https://api.honeyhive.ai";
+
 describe('evaluate function', () => {
     // Mock data
-    const testDataset = [
-        {
+    const testDataset = [{
+        "inputs": {
             "product_type": "electric vehicles",
-            "region": "western europe",
+            "region": "western europe", 
             "time_period": "2023"
+        },
+        "ground_truths": {
+            "output": "Mock analysis for electric vehicles in western europe"
         }
-    ];
+    },
+    {
+        "inputs": {
+            "product_type": "smartphones",
+            "region": "southeast asia",
+            "time_period": "2023"
+        },
+        "ground_truths": {
+            "output": "Mock analysis for smartphones in southeast asia"
+        }
+    },
+    {
+        "inputs": {
+            "product_type": "cloud computing services",
+            "region": "north america",
+            "time_period": "2023" 
+        },
+        "ground_truths": {
+            "output": "Mock analysis for cloud computing services in north america"
+        }
+    },
+    {
+        "inputs": {
+            "product_type": "renewable energy",
+            "region": "asia pacific",
+            "time_period": "2023"
+        },
+        "ground_truths": {
+            "output": "Mock analysis for renewable energy in asia pacific"
+        }
+    },
+    {
+        "inputs": {
+            "product_type": "artificial intelligence",
+            "region": "latin america",
+            "time_period": "2023"
+        },
+        "ground_truths": {
+            "output": "Mock analysis for artificial intelligence in latin america" 
+        }
+    }];
 
-    const FunctionToEvaluate = async (input: Record<string, any>) => {
+    const FunctionToEvaluate = async (inputs: Record<string, any>, ground_truths?: Record<string, any>) => {
         return {
-            role: 'assistant',
-            content: `Mock analysis for ${input.product_type} in ${input.region}`
+            content: `Mock analysis for ${inputs.product_type} in ${inputs.region}. ${ground_truths?.output}`
         };
     };
 
-    const sampleEvaluator = (input: Record<string, any>, output: any) => {
+    // Store the outputs for later assertion
+    let capturedOutputs: any[] = [];
+
+    const sampleEvaluator = (outputs: any, inputs: Record<string, any>, ground_truths?: Record<string, any>) => {
+        
+        const actualOutput = outputs.content;
+        const expectedOutput = `Mock analysis for ${inputs.product_type} in ${inputs.region}. ${ground_truths?.output}`;
+        
+        capturedOutputs.push({
+            actual: actualOutput,
+            expected: expectedOutput,
+            inputs,
+            ground_truths
+        });
+        
+        // Just return metrics without throwing
         return {
             sample_metric: 0.5,
             sample_metric_2: true
@@ -29,20 +86,29 @@ describe('evaluate function', () => {
     };
 
     it('should evaluate successfully with valid inputs', async () => {
+        // Clear captured outputs before test
+        capturedOutputs = [];
+        
         const result = await evaluate({
             evaluationFunction: FunctionToEvaluate,
             hh_api_key: HH_API_KEY,
             hh_project: HH_PROJECT_NAME,
-            name: 'eval-test',
+            name: 'test-suite-ts-1',
             dataset: testDataset,
             evaluators: [sampleEvaluator],
             suite: 'test-suite',
             server_url: SERVER_URL
         });
-
         expect(result).toBeDefined();
         expect(result.suite).toBe('test-suite');
-        // Add more specific assertions based on what evaluate should return
+        
+        // Now assert on the captured outputs
+        expect(capturedOutputs.length).toBeGreaterThan(0);
+        
+        // Check each captured output
+        capturedOutputs.forEach(output => {
+            expect(output.actual).toBe(output.expected); // This should fail
+        });
     });
 
     it('should use default suite when not provided', async () => {
@@ -54,12 +120,9 @@ describe('evaluate function', () => {
             dataset: testDataset,
             evaluators: [sampleEvaluator],
         });
-
         expect(result).toBeDefined();
         expect(result.suite).toBe('default');
-        // Add more specific assertions based on what evaluate should return
     });
-
 
     it('should throw error with invalid inputs', async () => {
         await expect(evaluate({


### PR DESCRIPTION
This PR:

- Adds support for ground truth in evaluationFunction and evaluators
- For in-code datasets, assumes list of nested dicts with keys `inputs` and `ground_truths`, as in Python version
- Evaluator args order changed from `inputs, outputs` to `outputs, inputs, ground_truths` to match with Python signature

This is a breaking change: anyone following our current TS example on Experiments Quickstart will have to change the dataset definition.