### PR TITLE
put sessionIds in evalResult

### DIFF
--- a/src/sdk/evaluation.ts
+++ b/src/sdk/evaluation.ts
@@ -563,7 +563,7 @@ class Evaluation {
 
         const duration = endTime - startTime;
         this.evalResult.stats['duration_s'] = Number((duration / 1000).toFixed(3));
-
+        this.evalResult.sessionIds = this.evaluationSessionIds;
         // Process results
         for (const result of results) {
             this.evalResult.data['input'].push(JSON.stringify(result['input']));


### PR DESCRIPTION
The sessionIds weren't being included in the evaluation results, even though they were being gathered in an internal class variable.

This PR includes the session ids into the eval results object.